### PR TITLE
Change AI button color to blue

### DIFF
--- a/content/smartButton.js
+++ b/content/smartButton.js
@@ -34,7 +34,7 @@ export class SmartButton {
 
   // Default color, can be overridden
   getDefaultColor() {
-    return '#4CAF50';
+    return '#007BFF';
   }
 
 
@@ -42,7 +42,7 @@ export class SmartButton {
   _onMouseOverDefault() {
     if (!this.button) return;
     this.button.style.boxShadow = '0 0 10px rgba(255, 255, 255, 0.8)';
-    this.button.style.backgroundColor = '#2dfa35'; // Lighter green
+    this.button.style.backgroundColor = '#58A6FF'; // Lighter green
   }
 
   // Default mouse out effect


### PR DESCRIPTION
This commit updates the AI button's color scheme.
The default color is changed from green to blue, and the hover color is updated to a lighter shade of blue for consistency.

Changes were made in `content/smartButton.js`:
- `getDefaultColor` now returns '#007BFF' (blue).
- `_onMouseOverDefault` now sets `backgroundColor` to '#58A6FF' (light blue).